### PR TITLE
Fix `gh-pages.yaml` workflow

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -62,7 +62,7 @@ jobs:
           uv run -qq python version.py >> $GITHUB_OUTPUT
           rm version.py
       - name: 'Build API Reference'
-        run: 'just reference'
+        run: 'just api-reference'
       - name: 'Deploy to GitHub Pages'
         run: |
           uv run mike set-default latest


### PR DESCRIPTION
Accidentially referenced non-existent recipe `reference` instead of `api-reference`.