### PR TITLE
Add `module` attr to `OpEngineFlepimop2Engine`

### DIFF
--- a/flepimop2-op_engine/src/flepimop2/engine/op_engine/__init__.py
+++ b/flepimop2-op_engine/src/flepimop2/engine/op_engine/__init__.py
@@ -11,11 +11,15 @@ Why:
 
 from __future__ import annotations
 
+from typing import Literal
+
 from .engine import _OpEngineFlepimop2EngineImpl
 
 
 class OpEngineFlepimop2Engine(_OpEngineFlepimop2EngineImpl):  # noqa: RUF067
     """Public op_engine-backed flepimop2 Engine (default-build enabled)."""
+
+    module: Literal["flepimop2.engine.op_engine"] = "flepimop2.engine.op_engine"
 
 
 __all__ = ["OpEngineFlepimop2Engine"]

--- a/flepimop2-op_engine/tests/test_engine.py
+++ b/flepimop2-op_engine/tests/test_engine.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 import numpy as np
 import pytest
 
+from flepimop2.engine.op_engine import OpEngineFlepimop2Engine
 from flepimop2.engine.op_engine.engine import (
     _OpEngineFlepimop2EngineImpl,  # noqa: PLC2701
 )
@@ -83,12 +84,11 @@ class _ImexSystem:
 # -----------------------------------------------------------------------------
 
 
-def test_engine_default_config_constructs() -> None:
-    """Engine can be constructed with defaults."""
-    engine = _OpEngineFlepimop2EngineImpl()
+def test_public_engine_wrapper_defines_module() -> None:
+    """Public engine wrapper satisfies flepimop2's concrete module contract."""
+    engine = OpEngineFlepimop2Engine()
 
     assert isinstance(engine, _OpEngineFlepimop2EngineImpl)
-    # Default comes from OpEngineEngineConfig; we do not assert its exact value here.
     assert engine.module == "flepimop2.engine.op_engine"
 
 

--- a/flepimop2-op_engine/tests/test_integration_cli.py
+++ b/flepimop2-op_engine/tests/test_integration_cli.py
@@ -44,7 +44,13 @@ def _write_config(config_path: Path) -> None:
     config_path.parent.mkdir(parents=True, exist_ok=True)
     cfg = {
         "name": "SIR_op_engine",
-        "system": [{"module": "wrapper", "script": "model_input/plugins/SIR.py"}],
+        "system": [
+            {
+                "module": "wrapper",
+                "state_change": "flow",
+                "script": "model_input/plugins/SIR.py",
+            }
+        ],
         "engine": [
             {
                 "module": "op_engine",


### PR DESCRIPTION
Added required `module` attribute to the `OpEngineFlepimop2Engine` class. Also updated the integration test's configuration to set 'state_change' for the wrapper system.

Closes #15.